### PR TITLE
Resolve limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,7 @@ rpc.onError(error => console.error);
 
 I'm a newbie in TypeScript world, so I want to enhance some of functionalities but I have to study more.
 
-1. I don't know how to support multi-parameters naturally while calling a function.
-2. I don't know how to omit a parameter if a method doesn't have any parameters.
-3. I don't know how to build type-safety between `on (for call)` and `on (for post)` in worker-side.
+1. I don't know how to build type-safety between `on (for call)` and `on (for post)` in worker-side.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ rpc.onError(error => console.error);
 
 I'm a newbie in TypeScript world, so I want to enhance some of functionalities but I have to study more.
 
-1. I don't know how to build type-safety between `on (for call)` and `on (for post)` in worker-side.
+1. I don't know how to omit `options` parameter of `on` method of RPCServer when `option` parameter is redundant.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,9 @@ rpc.onError(error => console.error);
 
 I'm a newbie in TypeScript world, so I want to enhance some of functionalities but I have to study more.
 
-1. Type parameters in `RPCClient` and `RPCServer` should be merged as one parameter. Now, it should be written as `WindowSide<keyof RPC, RPC>` to specify a list of methods with type-safety but I don't know how to use like `WindowSide<RPC>` with same constraints.
-2. I don't know how to support multi-parameters naturally while calling a function.
-3. I don't know how to omit a parameter if a method doesn't have any parameters.
-4. I don't know how to build type-safety between `on (for call)` and `on (for post)` in worker-side.
+1. I don't know how to support multi-parameters naturally while calling a function.
+2. I don't know how to omit a parameter if a method doesn't have any parameters.
+3. I don't know how to build type-safety between `on (for call)` and `on (for post)` in worker-side.
 
 ## License
 

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -9,13 +9,11 @@ interface AccumulatorRPC {
 }
 
 class AccumulatorClient extends rpc.RPCClient<
-  keyof AccumulatorRPC,
   AccumulatorRPC
-> {}
+  > { }
 class AccumulatorServer extends rpc.RPCServer<
-  keyof AccumulatorRPC,
   AccumulatorRPC
-> {}
+  > { }
 
 test('basic', async () => {
   const { windowChannel, workerChannel } = createChannels();

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -2,7 +2,7 @@ import * as rpc from '../src';
 import { createChannels } from './utils/channel';
 
 interface AccumulatorRPC {
-  addPost: (value: number) => void;
+  addPost: (value: number) => rpc.PostReturn;
   addSync: (value: number) => void;
   addAndGet: (value: number) => number;
   get: () => number;
@@ -30,19 +30,19 @@ test('basic', async () => {
     )
     .on('addSync', value => {
       workerValue += value;
-    })
-    .on('addAndGet', value => ({ result: workerValue += value }))
-    .on('get', () => ({ result: workerValue }))
+    }, null)
+    .on('addAndGet', value => ({ result: workerValue += value }), null)
+    .on('get', () => ({ result: workerValue }), null)
     .onError(console.error);
 
-  expect(await windowRPC.call('get', {})).toEqual(0);
+  expect(await windowRPC.call('get')).toEqual(0);
 
   windowRPC.post('addPost', 10);
-  expect(await windowRPC.call('get', {})).toEqual(10);
+  expect(await windowRPC.call('get')).toEqual(10);
 
   await windowRPC.call('addSync', 20);
-  expect(await windowRPC.call('get', {})).toEqual(30);
+  expect(await windowRPC.call('get')).toEqual(30);
 
   expect(await windowRPC.call('addAndGet', 30)).toEqual(60);
-  expect(await windowRPC.call('get', {})).toEqual(60);
+  expect(await windowRPC.call('get')).toEqual(60);
 });

--- a/__tests__/duplex.test.ts
+++ b/__tests__/duplex.test.ts
@@ -11,8 +11,8 @@ interface Pong {
 
 test('duplex', async () => {
   const { windowChannel, workerChannel } = createChannels();
-  const pingRPC = new rpc.RPCClient<keyof Ping, Ping>(windowChannel);
-  new rpc.RPCServer<keyof Ping, Ping>(workerChannel).on(
+  const pingRPC = new rpc.RPCClient<Ping>(windowChannel);
+  new rpc.RPCServer<Ping>(workerChannel).on(
     'ping',
     async remainCount => {
       console.log('ping', remainCount);
@@ -27,8 +27,8 @@ test('duplex', async () => {
     },
   );
 
-  const pongRPC = new rpc.RPCClient<keyof Pong, Pong>(workerChannel);
-  new rpc.RPCServer<keyof Pong, Pong>(windowChannel).on(
+  const pongRPC = new rpc.RPCClient<Pong>(workerChannel);
+  new rpc.RPCServer<Pong>(windowChannel).on(
     'pong',
     async remainCount => {
       console.log('pong', remainCount);

--- a/__tests__/duplex.test.ts
+++ b/__tests__/duplex.test.ts
@@ -24,7 +24,7 @@ test('duplex', async () => {
       }
       expect(result).toEqual(0);
       return { result };
-    },
+    }, null,
   );
 
   const pongRPC = new rpc.RPCClient<Pong>(workerChannel);
@@ -40,7 +40,7 @@ test('duplex', async () => {
       }
       expect(result).toEqual(0);
       return { result };
-    },
+    }, null,
   );
 
   await pingRPC.call('ping', 10);

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,11 +6,10 @@ import {
   RPCRequest,
 } from './types';
 import { ValueResolver } from './utils/promise';
-import { AnyFunction, AType, RType } from './utils/type';
+import { AnyFunction, AType, RPCDeclaration, RType } from './utils/type';
 
 export class RPCClient<
-  RPCMethod extends string,
-  RPC extends { [K in RPCMethod]: AnyFunction }
+  RPC extends RPCDeclaration<RPC>
 > extends AbstractRPC {
   private idSerial = 0;
   private resolvers: { [id: number]: ValueResolver<any> } = {};

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import {
   RPCRequest,
 } from './types';
 import { ValueResolver } from './utils/promise';
-import { RPCDeclaration } from './utils/type';
+import { CallMethodNames, PostMethodNames, RPCDeclaration } from './utils/type';
 
 const InternalCall = Symbol('RPCClient internal call');
 const InternalPost = Symbol('RPCClient internal post');
@@ -32,7 +32,7 @@ export class RPCWithTransfer<RPC extends RPCDeclaration<RPC>> {
 
 export class RPCClient<
   RPC extends RPCDeclaration<RPC>
-> extends AbstractRPC {
+  > extends AbstractRPC {
   private idSerial = 0;
   private resolvers: { [id: number]: ValueResolver<any> } = {};
 
@@ -45,14 +45,14 @@ export class RPCClient<
     return new RPCWithTransfer<RPC>(this, transfers);
   }
 
-  public call = <M extends keyof RPC>(
+  public call = <M extends CallMethodNames<RPC>>(
     method: M,
     ...args: Parameters<RPC[M]>
   ) => {
     return this[InternalCall](method, undefined, ...args);
   };
 
-  public [InternalCall] = <M extends keyof RPC>(
+  public [InternalCall] = <M extends CallMethodNames<RPC>>(
     method: M,
     transfer: Transferable[] | undefined,
     ...args: Parameters<RPC[M]>
@@ -69,14 +69,14 @@ export class RPCClient<
     });
   };
 
-  public post = <M extends keyof RPC>(
+  public post = <M extends PostMethodNames<RPC>>(
     method: M,
     ...args: Parameters<RPC[M]>
   ) => {
     this[InternalPost](method, undefined, ...args);
   };
 
-  public [InternalPost] = <M extends keyof RPC>(
+  public [InternalPost] = <M extends PostMethodNames<RPC>>(
     method: M,
     transfer: Transferable[] | undefined,
     ...args: Parameters<RPC[M]>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { RPCClient } from './client';
 export { RPCServer } from './server';
+export { PostReturn } from './utils/type';

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import {
   RPCRawRequest,
   RPCRawResponse,
 } from './types';
-import { AnyFunction, AType, RType } from './utils/type';
+import { AnyFunction, AType, RPCDeclaration, RType } from './utils/type';
 
 interface RPCHandlerRType<F extends AnyFunction> {
   result: RType<F>;
@@ -26,8 +26,7 @@ interface RPCHandlerTuple<F extends AnyFunction> {
 }
 
 export class RPCServer<
-  RPCMethod extends string,
-  RPC extends { [K in RPCMethod]: AnyFunction }
+  RPC extends RPCDeclaration<RPC>
 > extends AbstractRPC {
   private readonly handlers: {
     [method: string]: RPCHandlerTuple<any>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,16 +5,16 @@ import {
   RPCRawRequest,
   RPCRawResponse,
 } from './types';
-import { AnyFunction, AType, RPCDeclaration, RType } from './utils/type';
+import { AnyFunction, PromiseOrValue, RPCDeclaration } from './utils/type';
 
-interface RPCHandlerRType<F extends AnyFunction> {
-  result: RType<F>;
+type RPCHandlerRType<F extends AnyFunction> = ReturnType<F> extends void ? void : {
+  result: ReturnType<F>;
   transfer?: Transferable[];
-}
+};
 
 type RPCHandler<F extends AnyFunction> = (
-  args: AType<F>,
-) => RPCHandlerRType<F> | Promise<RPCHandlerRType<F>> | void;
+  ...args: Parameters<F>
+) => PromiseOrValue<RPCHandlerRType<F>>;
 
 interface RPCHandlerOptions {
   noReturn?: boolean;
@@ -29,15 +29,15 @@ export class RPCServer<
   RPC extends RPCDeclaration<RPC>
 > extends AbstractRPC {
   private readonly handlers: {
-    [method: string]: RPCHandlerTuple<any>;
-  } = {};
+    [method in keyof RPC]: RPCHandlerTuple<any>;
+  } = {} as any;
 
   constructor(channel: RPCChannel) {
     super(channel);
     this.channel.addEventListener('message', this.onMessage);
   }
 
-  public on = <M extends RPCMethod>(
+  public on = <M extends keyof RPC>(
     method: M,
     handler: RPCHandler<RPC[M]>,
     options?: RPCHandlerOptions,
@@ -55,7 +55,7 @@ export class RPCServer<
     if (!request.type) {
       return;
     }
-    const tuple = this.handlers[request.type];
+    const tuple = this.handlers[request.type as keyof RPC];
     if (!tuple) {
       return this.fireError(new Error(`No handler for ${request.type}`));
     }
@@ -72,7 +72,7 @@ export class RPCServer<
 
     let transfer: Transferable[] | undefined;
     try {
-      let result = handler(request.args);
+      let result = handler(...request.args);
       if (options && options.noReturn) {
         return;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { AnyFunction, AType } from './utils/type';
+import { AnyFunction } from "./utils/type";
 
 interface RPCInterface {
   [name: string]: AnyFunction;
@@ -7,13 +7,13 @@ interface RPCInterface {
 export interface RPCRequest<R extends RPCInterface, F extends keyof R> {
   id: number;
   type: F;
-  args: AType<R[F]>;
+  args: Parameters<R[F]>;
 }
 
 export interface RPCRawRequest {
   id: number;
   type: string;
-  args: any;
+  args: any[];
 }
 
 export interface RPCRawResponse {

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,11 +1,5 @@
-export type AnyFunction = (args: any) => any;
+export type AnyFunction = (...args: any[]) => any;
 
-export type AType<F extends AnyFunction> = F extends (args: infer A) => any
-  ? A
-  : void;
-
-export type RType<F extends AnyFunction> = F extends (args: any) => infer R
-  ? (R extends void ? undefined : R)
-  : never;
+export type PromiseOrValue<V> = Promise<V> | V;
 
 export type RPCDeclaration<RPC> = { [K in keyof RPC]: AnyFunction };

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -3,3 +3,17 @@ export type AnyFunction = (...args: any[]) => any;
 export type PromiseOrValue<V> = Promise<V> | V;
 
 export type RPCDeclaration<RPC> = { [K in keyof RPC]: AnyFunction };
+
+export interface PostReturn {
+  __post__: never;
+}
+
+export type PostMethodCondition<FN extends AnyFunction, T, F> = ReturnType<FN> extends void ? F : (ReturnType<FN> extends PostReturn ? T : F);
+
+export type CallMethodNames<
+  T extends { [K: string]: AnyFunction }
+  > = {
+    [K in keyof T]: PostMethodCondition<T[K], never, K>
+  }[keyof T];
+
+export type PostMethodNames<T extends { [K: string]: AnyFunction }> = Exclude<keyof T, CallMethodNames<T>>;

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -7,3 +7,5 @@ export type AType<F extends AnyFunction> = F extends (args: infer A) => any
 export type RType<F extends AnyFunction> = F extends (args: any) => infer R
   ? (R extends void ? undefined : R)
   : never;
+
+export type RPCDeclaration<RPC> = { [K in keyof RPC]: AnyFunction };


### PR DESCRIPTION
Resolve limitations, but there are some unexpected changes.
- `transfer` optional parameter passed by `withTransfer` method chaining
- `null` is needed for `options` parameter of `on (for call)` method of RPCServer
